### PR TITLE
fix(proxy, generator) fix internal call bug

### DIFF
--- a/src/Proxy/ProxyGenerator/Strategy/TmpFileGeneratorStrategy.php
+++ b/src/Proxy/ProxyGenerator/Strategy/TmpFileGeneratorStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenClassrooms\ServiceProxy\Proxy\ProxyGenerator\Strategy;
+
+use ProxyManager\GeneratorStrategy\GeneratorStrategyInterface;
+use Zend\Code\Generator\ClassGenerator;
+
+class TmpFileGeneratorStrategy implements GeneratorStrategyInterface
+{
+    public const DEFAULT_DIR = 'openclassrooms_service_proxy';
+
+    /**
+     * @var string|null
+     */
+    protected $path;
+
+    /**
+     * @param \ProxyManager\FileLocator\FileLocatorInterface $fileLocator
+     */
+    public function __construct(string $path = null)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(ClassGenerator $classGenerator): string
+    {
+        $code = $classGenerator->generate();
+        $path = $this->path ?? sys_get_temp_dir() . '/' . self::DEFAULT_DIR;
+        $fileName = $path . '/' . self::class . $classGenerator->getName() . '.tmp';
+        file_put_contents($fileName, "<?php\n" . $code);
+        /* @noinspection PhpIncludeInspection */
+        require $fileName;
+
+        return $code;
+    }
+}

--- a/tests/Doubles/CacheAnnotationClass.php
+++ b/tests/Doubles/CacheAnnotationClass.php
@@ -36,6 +36,11 @@ class CacheAnnotationClass
         return self::DATA;
     }
 
+    public function internalCallToCache()
+    {
+        return $this->onlyCache();
+    }
+
     /**
      * @Cache(lifetime=60)
      *
@@ -73,7 +78,7 @@ class CacheAnnotationClass
     {
         return self::DATA;
     }
-
+    
     /**
      * @Cache(namespace="'test-namespace' ~ param1.publicField")
      */

--- a/tests/ServiceProxyBuilderTest.php
+++ b/tests/ServiceProxyBuilderTest.php
@@ -4,6 +4,7 @@ namespace OpenClassrooms\ServiceProxy\Tests;
 
 use Doctrine\Common\Cache\ArrayCache;
 use OpenClassrooms\DoctrineCacheExtension\CacheProviderDecorator;
+use OpenClassrooms\ServiceProxy\Exceptions\InvalidCacheProviderException;
 use OpenClassrooms\ServiceProxy\Helpers\ServiceProxyHelper;
 use OpenClassrooms\ServiceProxy\ServiceProxyBuilderInterface;
 use OpenClassrooms\ServiceProxy\ServiceProxyCacheInterface;
@@ -42,16 +43,16 @@ class ServiceProxyBuilderTest extends TestCase
         $this->assertTrue($proxy->aMethodWithoutAnnotation());
         $this->assertTrue($proxy->aMethodWithoutServiceProxyAnnotation());
 
-        $this->assertNotInstanceOf('OpenClassrooms\ServiceProxy\ServiceProxyCacheInterface', $proxy);
+        $this->assertNotInstanceOf(ServiceProxyCacheInterface::class, $proxy);
         $this->assertTrue($proxy->aMethodWithoutAnnotation());
     }
 
     /**
      * @test
-     * @expectedException \OpenClassrooms\ServiceProxy\Exceptions\InvalidCacheProviderException
      */
     public function WithCacheAnnotationWithoutCacheProvider_ThrowException()
     {
+        $this->expectException(InvalidCacheProviderException::class);
         $inputClass = new CacheAnnotationClass();
         /* @var ServiceProxyCacheInterface|CacheAnnotationClass $proxy */
         $this->builder->create($inputClass)->build();

--- a/tests/ServiceProxyCacheTest.php
+++ b/tests/ServiceProxyCacheTest.php
@@ -83,6 +83,20 @@ class ServiceProxyCacheTest extends TestCase
     /**
      * @test
      */
+    public function WithInternalCall_ReturnData()
+    {
+        $inCacheData = 'InCacheData';
+        $this->cacheProviderDecorator->save(
+            md5('OpenClassrooms\ServiceProxy\Tests\Doubles\CacheAnnotationClass::onlyCache'),
+            $inCacheData
+        );
+        $data = $this->proxy->internalCallToCache();
+        $this->assertEquals($inCacheData, $data);
+    }
+    
+    /**
+     * @test
+     */
     public function WithLifeTime_ReturnData()
     {
         $data = $this->proxy->cacheWithLifeTime();


### PR DESCRIPTION
# Summary :
In this PR with the [PR](https://github.com/OpenClassrooms/ServiceProxyBundle/pull/6) the two issues detailed bellow :

## Internal methods calls ignore decoration (cache in our case) :
If we take a method `foo` which calls a method `bar` that have a cache annotation, the cache will be ignored.
The proxy generated will replace all methods in the class even the ones without annotations with a call to the child (real subject) class.
So `foo` of the child class will call also `bar` of that same class and thus the proxy (parent) will be ignored.
### solution:
Overriding only the annotated methods will resolve all cases where other methods call it, since the proxy inherits from the subject class
the context will stay on the proxy and thus calling the correct method.
This solution has some limitations though, the private properties states will be lost. The workaround found is to copy the state of the subject class to
the proxy and accessing private properties using the `Closure::call` php method.
*Calling the `$factoryDefinition->setMethodCalls($definition->getMethodCalls());` in ServiceProxyBundle Compiler Pass is essential to keep to sync the state of the source class and the proxy when decorating.*

## Using the ServiceProxyBundle with UseCaseBundle ignores proxies:
This issue is self-explanatory.
### solution
The solution is to make the ServiceProxyBundle compiler pass before the UseCaseBundle one, and keep the annotation and there imports
in the generated proxy.
This solution and specially keeping the use statements causes an issue with the default proxy generation strategy in the DEV environment, because it uses the `eval` which
doesn't support php autoload and thus can't resolve imports. the workaround was creating a new generation strategy that generates the proxy in a tmp folder
and requiring it just after and overriding it on each container compilation, we still have some limitations mainly a possible performance drop in the
container compilation in DEV environment.
*Calling the `$factoryDefinition->setTags($definition->getTags());` in ServiceProxyBundle Compiler Pass is essential to keep tags of the source service which makes the UseCaseBundle Compiler take into account proxies.*
