### PR TITLE
transaction: handle exceptions mapping

### DIFF
--- a/docs/Interceptor/transaction.md
+++ b/docs/Interceptor/transaction.md
@@ -22,3 +22,25 @@ class AUseCase
     }
 }
 ```
+
+Exceptions occurring during the transaction can be mapped so that the method 
+returns another exception instead
+
+```php
+
+class AUseCase
+{
+    /**
+     * @Transaction(exceptions={
+     *     "SomeInfrastructureException"="SomeDomainException"
+     * })
+     */
+    public function execute(UseCaseRequest $useCaseRequest)
+    {
+        // do things
+        
+        return $useCaseResponse;
+    }
+}
+```
+

--- a/src/Annotation/Transaction.php
+++ b/src/Annotation/Transaction.php
@@ -12,6 +12,32 @@ use OpenClassrooms\ServiceProxy\Handler\Contract\TransactionHandler;
  */
 final class Transaction extends Annotation
 {
+    /**
+     * @var array<class-string, class-string>
+     */
+    private array $exceptions = [];
+
+    /**
+     * @return array<class-string, class-string>
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+
+    /**
+     * @param array<class-string, class-string> $exceptions
+     */
+    public function setExceptions(array $exceptions): void
+    {
+        $this->exceptions = $exceptions;
+    }
+
+    public function hasMappedExceptions(): bool
+    {
+        return \count($this->exceptions) > 0;
+    }
+
     public function getHandlerClass(): string
     {
         return TransactionHandler::class;

--- a/tests/Double/Stub/Transaction/TransactionAnnotatedClass.php
+++ b/tests/Double/Stub/Transaction/TransactionAnnotatedClass.php
@@ -18,7 +18,7 @@ class TransactionAnnotatedClass
     /**
      * @Transaction
      */
-    public function annotatedMethodWithException(): void
+    public function annotatedMethodThatThrowsException(): void
     {
         throw new \RuntimeException();
     }
@@ -28,6 +28,16 @@ class TransactionAnnotatedClass
      */
     public function annotatedMethod(): void
     {
+    }
+
+    /**
+     * @Transaction(exceptions={
+     *     "\RuntimeException"="\InvalidArgumentException"
+     * })
+     */
+    public function annotatedMethodWithExceptionMappingThatThrowsException(): void
+    {
+        throw new \RuntimeException();
     }
 
     /**
@@ -42,10 +52,10 @@ class TransactionAnnotatedClass
     /**
      * @Transaction
      */
-    public function nestedAnnotatedMethodWithException(): void
+    public function nestedAnnotatedMethodThatThrowsException(): void
     {
         $self = new self();
-        $self->annotatedMethodWithException();
+        $self->annotatedMethodThatThrowsException();
     }
 
     /**

--- a/tests/Interceptor/TransactionInterceptorTest.php
+++ b/tests/Interceptor/TransactionInterceptorTest.php
@@ -34,10 +34,23 @@ final class TransactionInterceptorTest extends TestCase
     public function testExceptionTransactionRollBack(): void
     {
         try {
-            $this->proxy->annotatedMethodWithException();
+            $this->proxy->annotatedMethodThatThrowsException();
             /** @noinspection PhpUnreachableStatementInspection */
             $this->fail();
         } catch (\Exception $e) {
+            $this->assertFalse($this->handler->committed);
+            $this->assertTrue($this->handler->rollBacked);
+        }
+    }
+
+    public function testExceptionTransactionRollBackWithExceptionMapping(): void
+    {
+        try {
+            $this->proxy->annotatedMethodWithExceptionMappingThatThrowsException();
+            /** @noinspection PhpUnreachableStatementInspection */
+            $this->fail();
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
             $this->assertFalse($this->handler->committed);
             $this->assertTrue($this->handler->rollBacked);
         }
@@ -53,7 +66,7 @@ final class TransactionInterceptorTest extends TestCase
     public function testExceptionNestedTransactionRollBack(): void
     {
         try {
-            $this->proxy->nestedAnnotatedMethodWithException();
+            $this->proxy->nestedAnnotatedMethodThatThrowsException();
             $this->fail();
         } catch (\Exception $e) {
             $this->assertFalse($this->handler->committed);


### PR DESCRIPTION
Handles the possibility of mapping exceptions, such as:

```php
    /**
     * @Transaction(exceptions={
     *     "SomeInfrastructureException"="SomeDomainException"
     * })
     */
````