### PR TITLE
fix(service-proxy): Fix eventName that was missing in the dispatcher

### DIFF
--- a/src/Handler/Handler/Event/SymfonyDispatcherEventHandler.php
+++ b/src/Handler/Handler/Event/SymfonyDispatcherEventHandler.php
@@ -25,7 +25,7 @@ final class SymfonyDispatcherEventHandler implements EventHandler
 
     public function send(object $event): void
     {
-        $this->eventDispatcher->dispatch($event);
+        $this->eventDispatcher->dispatch($event, $event->eventName);
     }
 
     public function getName(): string


### PR DESCRIPTION
Fix the eventName that was missing in the dispatcher.

The missing eventName leads to ClassName event name, which is not what we want in our projects

Example:
For a UseCase named `SubmitStudentApplication`, if we don't pass the `event->eventName` in the `dispatch()`, the dispatcher guess the eventName to `SubmitStudentApplication`, instead of the name we want : `use_case.post.submit_student_application`
