### PR TITLE
fix(service-proxy): Fix eventName that was missing in the dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
     "symfony/event-dispatcher": "^5.0 || ^6.0",
     "symfony/security-bundle": "^5.0 || ^6.0",
     "symfony/messenger": "^5.0 || ^6.0",
-    "doctrine/orm": "~2.5 || ^3.0"
+    "doctrine/orm": "~2.5 || ^3.0",
+    "symfony/stopwatch": "^5.4"
   },
   "suggest": {
     "symfony/dependency-injection": "For Symfony integration",

--- a/src/Handler/Handler/Event/SymfonyDispatcherEventHandler.php
+++ b/src/Handler/Handler/Event/SymfonyDispatcherEventHandler.php
@@ -25,7 +25,7 @@ final class SymfonyDispatcherEventHandler implements EventHandler
 
     public function send(object $event): void
     {
-        $this->eventDispatcher->dispatch($event);
+        $this->eventDispatcher->dispatch($event, $event->eventName);
     }
 
     public function getName(): string

--- a/tests/Double/Mock/Event/EventHandlerMock.php
+++ b/tests/Double/Mock/Event/EventHandlerMock.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace OpenClassrooms\ServiceProxy\Tests\Double\Mock\Event;
 
 use OpenClassrooms\ServiceProxy\Handler\Contract\EventHandler;
+use OpenClassrooms\ServiceProxy\Handler\Handler\Event\SymfonyDispatcherEventHandler;
 use OpenClassrooms\ServiceProxy\Model\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class EventHandlerMock implements EventHandler
 {
     private array $events = [];
+
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct()
+    {
+        $this->eventDispatcher = new TraceableEventDispatcherMock();
+    }
 
     public function getEvent(string $name, int $position = 0): Event
     {
@@ -59,7 +68,19 @@ final class EventHandlerMock implements EventHandler
      */
     public function send(object $event): void
     {
+        $symfonyDispatcherEventHandler = new SymfonyDispatcherEventHandler($this->eventDispatcher);
+        $symfonyDispatcherEventHandler->send($event);
         $this->events[] = $event;
+    }
+
+    public function getOrphanedEvents(): array
+    {
+        return $this->eventDispatcher->getOrphanedEvents();
+    }
+
+    public function addListener(string $eventName, callable $listener): void
+    {
+        $this->eventDispatcher->addListener($eventName, $listener);
     }
 
     public function isDefault(): bool

--- a/tests/Double/Mock/Event/TraceableEventDispatcherMock.php
+++ b/tests/Double/Mock/Event/TraceableEventDispatcherMock.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenClassrooms\ServiceProxy\Tests\Double\Mock\Event;
+
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class TraceableEventDispatcherMock extends TraceableEventDispatcher
+{
+    public function __construct()
+    {
+        parent::__construct(new EventDispatcher(), new Stopwatch());
+    }
+}

--- a/tests/Interceptor/EventInterceptorTest.php
+++ b/tests/Interceptor/EventInterceptorTest.php
@@ -63,6 +63,14 @@ final class EventInterceptorTest extends TestCase
         }
     }
 
+    public function testEventIsNotOrphan(): void
+    {
+            $eventName = 'use_case.post.event_annotated_class';
+            $this->handler->addListener($eventName, fn () => []);
+            $response = $this->proxy->eventPost('whatever');
+            $this->assertCount(0, $this->handler->getOrphanedEvents());
+    }
+
     public function testMultiEventsSendMultiple(): void
     {
         $response = $this->proxy->multiEvents('whatever');


### PR DESCRIPTION
The missing eventName leads to ClassName event name, which is not what we want in our projects