### PR TITLE
Remove exists call when fetching a key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,9 @@
     "symfony/security-bundle": "For Symfony integration with Security",
     "doctrine/orm": "For Doctrine integration with Transaction and legacy Cache"
   },
+  "conflict": {
+    "psr/cache": ">=3.0"
+  },
   "extra": {
     "branch-alias": {
       "dev-master": "2.0.x-dev"

--- a/src/Handler/Contract/CacheHandler.php
+++ b/src/Handler/Contract/CacheHandler.php
@@ -4,20 +4,17 @@ declare(strict_types=1);
 
 namespace OpenClassrooms\ServiceProxy\Handler\Contract;
 
+use Psr\Cache\CacheItemInterface;
+
 interface CacheHandler extends AnnotationHandler
 {
-    /**
-     * @return mixed
-     */
-    public function fetch(string $poolName, string $id);
+    public function fetch(string $poolName, string $id): CacheItemInterface;
 
     /**
      * @param array<int, string> $tags
      * @param mixed              $data
      */
     public function save(string $poolName, string $id, $data, ?int $lifeTime = null, array $tags = []): void;
-
-    public function contains(string $poolName, string $id): bool;
 
     /**
      * @param array<int, string> $tags

--- a/src/Handler/Impl/Cache/DoctrineCacheHandler.php
+++ b/src/Handler/Impl/Cache/DoctrineCacheHandler.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace OpenClassrooms\ServiceProxy\Handler\Impl\Cache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\CacheItem;
 use OpenClassrooms\DoctrineCacheExtension\CacheProviderDecorator;
 use OpenClassrooms\ServiceProxy\Handler\Contract\CacheHandler;
 use OpenClassrooms\ServiceProxy\Handler\Impl\ConfigurableHandler;
+use Psr\Cache\CacheItemInterface;
 
 /**
  * @deprecated use SymfonyCacheHandler instead
@@ -24,12 +26,14 @@ final class DoctrineCacheHandler implements CacheHandler
         $this->name = $name;
     }
 
-    public function fetch(string $poolName, string $id)
+    public function fetch(string $poolName, string $id): CacheItemInterface
     {
         $tags = explode('|', $id);
         $id = array_shift($tags);
 
-        return $this->cacheProvider->fetchWithNamespace($id, $tags[0] ?? null);
+        $value = $this->cacheProvider->fetchWithNamespace($id, $tags[0] ?? null);
+
+        return new CacheItem($id, $value, $value !== false);
     }
 
     public function save(string $poolName, string $id, $data, ?int $lifeTime = null, array $tags = []): void

--- a/src/Handler/Impl/Cache/SymfonyCacheHandler.php
+++ b/src/Handler/Impl/Cache/SymfonyCacheHandler.php
@@ -6,31 +6,31 @@ namespace OpenClassrooms\ServiceProxy\Handler\Impl\Cache;
 
 use OpenClassrooms\ServiceProxy\Handler\Contract\CacheHandler;
 use OpenClassrooms\ServiceProxy\Handler\Impl\ConfigurableHandler;
-use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Psr\Cache\CacheItemInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 final class SymfonyCacheHandler implements CacheHandler
 {
     use ConfigurableHandler;
 
     /**
-     * @var iterable<string, TagAwareAdapter>
+     * @var iterable<string, TagAwareAdapterInterface>
      */
     private iterable $pools;
 
     /**
-     * @param iterable<string, TagAwareAdapter> $pools
+     * @param iterable<string, TagAwareAdapterInterface> $pools
      */
     public function __construct(iterable $pools = [])
     {
         $this->pools = $pools;
     }
 
-    public function fetch(string $poolName, string $id): mixed
+    public function fetch(string $poolName, string $id): CacheItemInterface
     {
         $pool = $this->getPool($poolName);
 
-        return $pool->getItem($id)
-            ->get();
+        return $pool->getItem($id);
     }
 
     public function save(string $poolName, string $id, $data, ?int $ttl = null, array $tags = []): void
@@ -63,7 +63,7 @@ final class SymfonyCacheHandler implements CacheHandler
         return 'symfony_cache';
     }
 
-    private function getPool(string $poolName): TagAwareAdapter
+    private function getPool(string $poolName): TagAwareAdapterInterface
     {
         $existingPools = [...$this->pools];
 

--- a/src/Interceptor/Impl/CacheInterceptor.php
+++ b/src/Interceptor/Impl/CacheInterceptor.php
@@ -90,7 +90,9 @@ final class CacheInterceptor extends AbstractInterceptor implements SuffixInterc
         $missedPools = [];
 
         foreach ($pools as $pool) {
-            if (!$handler->contains($pool, $cacheKey)) {
+            $data = $handler->fetch($pool, $cacheKey);
+
+            if (!$data->isHit()) {
                 $missedPools[] = $pool;
 
                 self::$misses[$pool] = self::$misses[$pool] ?? [];
@@ -99,8 +101,6 @@ final class CacheInterceptor extends AbstractInterceptor implements SuffixInterc
                 continue;
             }
 
-            $data = $handler->fetch($pool, $cacheKey);
-
             self::$hits[$pool] = self::$hits[$pool] ?? [];
             self::$hits[$pool][] = $cacheKey;
 
@@ -108,13 +108,13 @@ final class CacheInterceptor extends AbstractInterceptor implements SuffixInterc
                 $handler->save(
                     $missedPool,
                     $cacheKey,
-                    $data,
+                    $data->get(),
                     $attribute->ttl ?? $this->config->defaultTtl,
                     $this->getTags($instance, $attribute, $data)
                 );
             }
 
-            return new Response($data, true);
+            return new Response($data->get(), true);
         }
 
         return new Response(null, false);

--- a/src/Interceptor/Impl/LegacyCacheInterceptor.php
+++ b/src/Interceptor/Impl/LegacyCacheInterceptor.php
@@ -41,11 +41,11 @@ final class LegacyCacheInterceptor extends AbstractInterceptor implements Suffix
 
         // this is needed to solve a bug (when the false is stored in the cache)
 
-        if ($data === false) {
+        if (!$data->isHit()) {
             return new Response(null, false);
         }
 
-        return new Response($data, true);
+        return new Response($data->get(), true);
     }
 
     public function suffix(Instance $instance): Response

--- a/tests/Double/Mock/Cache/CacheHandlerMock.php
+++ b/tests/Double/Mock/Cache/CacheHandlerMock.php
@@ -6,6 +6,7 @@ namespace OpenClassrooms\ServiceProxy\Tests\Double\Mock\Cache;
 
 use OpenClassrooms\ServiceProxy\Handler\Contract\CacheHandler;
 use OpenClassrooms\ServiceProxy\Handler\Impl\Cache\SymfonyCacheHandler;
+use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
@@ -31,7 +32,7 @@ final class CacheHandlerMock implements CacheHandler
         ], $name);
     }
 
-    public function fetch(string $poolName, string $id)
+    public function fetch(string $poolName, string $id): CacheItemInterface
     {
         return $this->wrappedHandler->fetch($poolName, $id);
     }
@@ -41,11 +42,6 @@ final class CacheHandlerMock implements CacheHandler
         self::$lifeTime = $lifeTime;
 
         $this->wrappedHandler->save($poolName, $id, $data, $lifeTime, $tags);
-    }
-
-    public function contains(string $poolName, string $id): bool
-    {
-        return $this->wrappedHandler->contains($poolName, $id);
     }
 
     public function isDefault(): bool

--- a/tests/Double/Mock/Cache/DoctrineCacheHandlerMock.php
+++ b/tests/Double/Mock/Cache/DoctrineCacheHandlerMock.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use OpenClassrooms\DoctrineCacheExtension\CacheProviderDecorator;
 use OpenClassrooms\ServiceProxy\Handler\Contract\CacheHandler;
 use OpenClassrooms\ServiceProxy\Handler\Impl\Cache\DoctrineCacheHandler;
+use Psr\Cache\CacheItemInterface;
 
 final class DoctrineCacheHandlerMock implements CacheHandler
 {
@@ -30,7 +31,7 @@ final class DoctrineCacheHandlerMock implements CacheHandler
         $this->wrappedHandler = new DoctrineCacheHandler($cacheProvider, $name);
     }
 
-    public function fetch(string $poolName, string $id)
+    public function fetch(string $poolName, string $id): CacheItemInterface
     {
         return $this->wrappedHandler->fetch($poolName, $id);
     }
@@ -40,11 +41,6 @@ final class DoctrineCacheHandlerMock implements CacheHandler
         self::$lifeTime = $lifeTime;
 
         $this->wrappedHandler->save($poolName, $id, $data, $lifeTime, $tags);
-    }
-
-    public function contains(string $poolName, string $id, array $tags = []): bool
-    {
-        return $this->wrappedHandler->contains($poolName, $id);
     }
 
     public function invalidateTags(string $poolName, array $tags): void

--- a/tests/Interceptor/LegacyCacheInterceptorTest.php
+++ b/tests/Interceptor/LegacyCacheInterceptorTest.php
@@ -57,10 +57,10 @@ final class LegacyCacheInterceptorTest extends TestCase
             $this->fail('Exception should be thrown');
         } catch (\Exception $e) {
             $this->assertFalse(
-                $this->cacheHandlerMock->contains(
+                $this->cacheHandlerMock->fetch(
                     'default',
                     CacheAnnotatedClass::class . '::cacheMethodWithException'
-                )
+                )->isHit()
             );
         }
     }
@@ -74,7 +74,7 @@ final class LegacyCacheInterceptorTest extends TestCase
             $this->cacheHandlerMock->fetch(
                 'default',
                 md5(CacheAnnotatedClass::class . '::annotatedMethod')
-            )
+            )->get()
         );
     }
 
@@ -113,14 +113,14 @@ final class LegacyCacheInterceptorTest extends TestCase
     {
         $data = $this->proxy->cacheWithId();
         $this->assertEquals(CacheAnnotatedClass::DATA, $data);
-        $this->assertEquals(CacheAnnotatedClass::DATA, $this->cacheHandlerMock->fetch('default', 'test'));
+        $this->assertEquals(CacheAnnotatedClass::DATA, $this->cacheHandlerMock->fetch('default', 'test')->get());
     }
 
     public function testWithIdAndParametersReturnData(): void
     {
         $data = $this->proxy->cacheWithIdAndParameters(new ParameterClassStub(), 'param 2');
         $this->assertEquals(CacheAnnotatedClass::DATA, $data);
-        $this->assertEquals(CacheAnnotatedClass::DATA, $this->cacheHandlerMock->fetch('default', 'test1'));
+        $this->assertEquals(CacheAnnotatedClass::DATA, $this->cacheHandlerMock->fetch('default', 'test1')->get());
     }
 
     public function testWithNamespaceReturnData(): void
@@ -132,9 +132,9 @@ final class LegacyCacheInterceptorTest extends TestCase
             CacheAnnotatedClass::DATA,
             $this->cacheHandlerMock->fetch(
                 'default',
-                $this->cacheHandlerMock->fetch('default', md5('test-namespace')) .
+                $this->cacheHandlerMock->fetch('default', md5('test-namespace'))->get() .
                 md5(CacheAnnotatedClass::class . '::cacheWithNamespace')
-            )
+            )->get()
         );
     }
 
@@ -147,9 +147,9 @@ final class LegacyCacheInterceptorTest extends TestCase
             CacheAnnotatedClass::DATA,
             $this->cacheHandlerMock->fetch(
                 'default',
-                $this->cacheHandlerMock->fetch('default', md5('test-namespace')) .
+                $this->cacheHandlerMock->fetch('default', md5('test-namespace'))->get() .
                 'toto'
-            )
+            )->get()
         );
     }
 
@@ -162,12 +162,12 @@ final class LegacyCacheInterceptorTest extends TestCase
             CacheAnnotatedClass::DATA,
             $this->cacheHandlerMock->fetch(
                 'default',
-                $this->cacheHandlerMock->fetch('default', md5('test-namespace1')) .
+                $this->cacheHandlerMock->fetch('default', md5('test-namespace1'))->get() .
                 md5(
                     CacheAnnotatedClass::class . '::cacheWithNamespaceAndParameters'
                     . '::' . serialize(new ParameterClassStub()) . '::' . serialize('param 2')
                 )
-            )
+            )->get()
         );
     }
 }


### PR DESCRIPTION
This PR leverage the Psr4 CacheItemInterface to remove the contains call and avoid double call the cache adapter on every fetch. 

Also this PR reduce the type constraint of the SymfonyCacheHandler to permit usage of native TagAwareAdapater like the RedisTagAwareAdapter.