### PR TITLE
Remove parameter type on proxified methods to allow parameter validation

### DIFF
--- a/src/Generator/Method/InterceptedMethod.php
+++ b/src/Generator/Method/InterceptedMethod.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace OpenClassrooms\ServiceProxy\Generator\Method;
 
 use Laminas\Code\Generator\Exception\InvalidArgumentException;
+use Laminas\Code\Generator\ParameterGenerator;
+use Laminas\Code\Generator\PromotedParameterGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Reflection\MethodReflection;
+use ReflectionMethod;
 
 use ProxyManager\Generator\MethodGenerator;
 
@@ -40,6 +43,25 @@ final class InterceptedMethod extends MethodGenerator
             $suffixInterceptors,
             $originalMethod
         ));
+
+        return $method;
+    }
+
+    /**
+     * @return static
+     */
+    public static function fromReflectionWithoutBodyAndDocBlock(MethodReflection $reflectionMethod): self
+    {
+        /** @var static $method */
+        $method = parent::fromReflectionWithoutBodyAndDocBlock($reflectionMethod);
+
+        foreach ($reflectionMethod->getParameters() as $reflectionParameter) {
+            $method->setParameter(
+                $reflectionParameter->isPromoted()
+                    ? PromotedParameterGenerator::fromReflection($reflectionParameter)
+                    : InterceptedParameter::fromReflection($reflectionParameter)
+            );
+        }
 
         return $method;
     }

--- a/src/Generator/Method/InterceptedParameter.php
+++ b/src/Generator/Method/InterceptedParameter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OpenClassrooms\ServiceProxy\Generator\Method;
+
+use Laminas\Code\Generator\ParameterGenerator;
+use Laminas\Code\Reflection\ParameterReflection;
+
+class InterceptedParameter extends ParameterGenerator
+{
+    /**
+     * @return ParameterGenerator
+     */
+    public static function fromReflection(ParameterReflection $reflectionParameter)
+    {
+        $param = parent::fromReflection($reflectionParameter);
+        $param->type = null;
+
+        return $param;
+    }
+}

--- a/src/Interceptor/Contract/AbstractInterceptor.php
+++ b/src/Interceptor/Contract/AbstractInterceptor.php
@@ -110,7 +110,7 @@ abstract class AbstractInterceptor
         }
 
         throw new \InvalidArgumentException(
-            'All handlers must implement AnnotationHandler interface.'
+            'All handlers must implement AnnotationHandler interface. Handler : ' . \get_class($handler)
         );
     }
 


### PR DESCRIPTION
We want to be able to validate parameters given to a `Controller::__invoke` method.
We will add a `#[RequestValidation]` attribute later on
But to be able to do it, we need to enlarge the types of the parameters on the methods of the proxified object.

So instead of
`Controller::__invoke(int $sessionId)
`

it becomes 
`Controller::__invoke($sessionId)
`

This way the proxy can be called even with bad parameters, then it will be checked with an `#[RequestValidation]` Attribute Handler, and if something is bad in the request (according to the OpenApi Doc), then a 400 will be thrown 