### PR TITLE
patch(model): Add a getter on Model Event to ease migration

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -86,4 +86,19 @@ final class Event
 
         return "{$moment->value}.{$name}";
     }
+
+    public function getUseCaseRequest(): mixed
+    {
+        return $this->parameters['useCaseRequest'];
+    }
+
+    public function getUseCaseResponse(): mixed
+    {
+        return $this->response;
+    }
+
+    public function getUseCaseException(): mixed
+    {
+        return $this->exception;
+    }
 }


### PR DESCRIPTION

Facilitate the migration to new service-proxy, 
Example : 
https://github.com/simpleit/SdZv4/pull/15051/files

Avoid having to change : 
```
        $useCaseRequest = $event->getUseCaseRequest();
```
into 
```
        $useCaseRequest = $event->parameters['useCaseRequest'];
```