### PR TITLE
Cache invalidiation is trigger after the transaction

### DIFF
--- a/src/Helper/TypesExtractor.php
+++ b/src/Helper/TypesExtractor.php
@@ -131,10 +131,11 @@ final class TypesExtractor
                 $types = $this->typeHelper->getTypes($tag->value, $nameScope);
                 foreach ($types as $type) {
                     $classNames[] = $type->getClassName() ?? $type->getBuiltinType();
-                    if ($type->isCollection()) {
-                        foreach ($type->getCollectionValueTypes() as $collectionValueType) {
-                            $classNames[] = $collectionValueType->getClassName() ?? $collectionValueType->getBuiltinType();
-                        }
+                    foreach ($type->getCollectionValueTypes() as $collectionType) {
+                        $classNames[] = $collectionType->getClassName() ?? $collectionType->getBuiltinType();
+                    }
+                    foreach ($type->getCollectionKeyTypes() as $collectionType) {
+                        $classNames[] = $collectionType->getClassName() ?? $collectionType->getBuiltinType();
                     }
                 }
             }

--- a/src/Interceptor/Impl/InvalidateCacheInterceptor.php
+++ b/src/Interceptor/Impl/InvalidateCacheInterceptor.php
@@ -45,7 +45,7 @@ final class InvalidateCacheInterceptor extends AbstractInterceptor implements Su
 
     public function getSuffixPriority(): int
     {
-        return 40;
+        return 30;
     }
 
     /**

--- a/src/Interceptor/Impl/TransactionInterceptor.php
+++ b/src/Interceptor/Impl/TransactionInterceptor.php
@@ -69,7 +69,7 @@ final class TransactionInterceptor extends AbstractInterceptor implements Prefix
 
     public function getSuffixPriority(): int
     {
-        return 30;
+        return 40;
     }
 
     /**

--- a/tests/ProxyFactoryTest.php
+++ b/tests/ProxyFactoryTest.php
@@ -9,6 +9,7 @@ use OpenClassrooms\ServiceProxy\Interceptor\Contract\PrefixInterceptor;
 use OpenClassrooms\ServiceProxy\Interceptor\Contract\SuffixInterceptor;
 use OpenClassrooms\ServiceProxy\Interceptor\Impl\CacheInterceptor;
 use OpenClassrooms\ServiceProxy\Interceptor\Impl\EventInterceptor;
+use OpenClassrooms\ServiceProxy\Interceptor\Impl\InvalidateCacheInterceptor;
 use OpenClassrooms\ServiceProxy\Interceptor\Impl\SecurityInterceptor;
 use OpenClassrooms\ServiceProxy\Interceptor\Impl\TransactionInterceptor;
 use OpenClassrooms\ServiceProxy\ProxyFactory;
@@ -35,6 +36,7 @@ final class ProxyFactoryTest extends TestCase
                 new EventInterceptor([new EventHandlerMock()]),
                 new TransactionInterceptor([new TransactionHandlerMock()]),
                 new SecurityInterceptor([new SecurityHandlerMock()]),
+                new InvalidateCacheInterceptor(),
             ]
         );
     }
@@ -93,9 +95,9 @@ final class ProxyFactoryTest extends TestCase
         $this->assertEquals(
             [
                 TransactionInterceptor::class,
+                InvalidateCacheInterceptor::class,
                 CacheInterceptor::class,
                 EventInterceptor::class,
-                SecurityInterceptor::class,
             ],
             $suffixInterceptorsClasses
         );

--- a/tests/ProxyTestTrait.php
+++ b/tests/ProxyTestTrait.php
@@ -42,10 +42,12 @@ trait ProxyTestTrait
      */
     private function getProxyFactory(array $interceptors): ProxyFactory
     {
+        $filter = static fn (string $type) => static fn (object $interceptor) => is_a($interceptor, $type);
+
         return new ProxyFactory(
             new ProxyFactoryConfiguration(self::$cacheDir),
-            $interceptors,
-            $interceptors,
+            array_filter($interceptors, $filter(PrefixInterceptor::class)),
+            array_filter($interceptors, $filter(SuffixInterceptor::class))
         );
     }
 }


### PR DESCRIPTION
cc @nenrici 

during a bug investigation, we saw that the cache invalidation interceptor was called before the transaction interceptor during the suffix phase. 

This PR fix the ordering so cache will be invalidated after the transaction.