### PR TITLE
chore: migrate phpdoc parser to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "symfony/filesystem": "^5.0 || ^6.0",
     "symfony/property-info": "^5.0 || ^6.0",
     "phpdocumentor/reflection-docblock": "^5.0",
-    "phpstan/phpdoc-parser": "^1.24",
+    "phpstan/phpdoc-parser": "^2.0",
     "webmozart/assert": "^1.11",
     "jolicode/automapper": "^9.2"
   },

--- a/src/Helper/TypesExtractor.php
+++ b/src/Helper/TypesExtractor.php
@@ -9,6 +9,7 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 use Symfony\Component\PropertyInfo\PhpStan\NameScope;
 use Symfony\Component\PropertyInfo\PhpStan\NameScopeFactory;
 use Symfony\Component\PropertyInfo\Util\PhpStanTypeHelper;
@@ -30,13 +31,15 @@ final class TypesExtractor
 
     public function __construct()
     {
-        $this->lexer = new Lexer();
+        $parserConfig = new ParserConfig([]);
+        $this->lexer = new Lexer($parserConfig);
         $this->nameScopeFactory = new NameScopeFactory();
         $this->typeHelper = new PhpStanTypeHelper();
 
-        $constExprParser = new ConstExprParser();
+        $constExprParser = new ConstExprParser($parserConfig);
         $this->phpDocParser = new PhpDocParser(
-            new TypeParser($constExprParser),
+            $parserConfig,
+            new TypeParser($parserConfig, $constExprParser),
             $constExprParser
         );
     }


### PR DESCRIPTION
## Summary

- require `phpstan/phpdoc-parser` v2
- configure the lexer and parser stack with a shared `ParserConfig`
- preserve PHPDoc type extraction used for cache invalidation

## Tests

- `composer validate --strict`
- `composer check-cs`
- `php -d memory_limit=-1 vendor/bin/phpstan analyse -c phpstan.neon --ansi`
- `composer unit`